### PR TITLE
Show leaderboard on round result screen

### DIFF
--- a/src/components/ResultChart.tsx
+++ b/src/components/ResultChart.tsx
@@ -17,7 +17,7 @@ const ResultChart: React.FC<IResultChartProps> = ({ data }) => {
 
   return (
     <ResponsiveContainer>
-      <BarChart data={sanitisedData} margin={{ top: 50 }}>
+      <BarChart data={sanitisedData} margin={{ top: 32 }}>
         <XAxis dataKey="name" tickLine={false} stroke="white" />
 
         <Bar dataKey="value">

--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -111,6 +111,10 @@ export const GAME_ROUND_VOTE: Game = {
 
 export const GAME_ROUND_RESULTS: Game = {
   ...GAME_ROUND_VOTE,
+  players: GAME_ROUND_VOTE.players.map((item) => ({
+    ...item,
+    points: randomIntFromInterval(0, 4),
+  })),
   rounds: GAME_ROUND_VOTE.rounds.map((item) =>
     item.order === 1
       ? {

--- a/src/screens/final-results.tsx
+++ b/src/screens/final-results.tsx
@@ -12,9 +12,25 @@ const FinalResultsScreen: React.FC<RoundScreenProps> = ({ game, round, player })
   });
 
   return (
-    <div className="flex flex-col items-center h-full py-12 space-y-12">
-      <h1 className="text-4xl font-bold text-white">The results are in</h1>
-      <ResultChart data={resultData} />
+    <div className="h-full py-12 space-y-12">
+      <h1 className="text-4xl font-bold text-center text-white">The results are in</h1>
+      <div className="h-96">
+        <ResultChart data={resultData} />
+      </div>
+
+      <section>
+        <h2 className="text-2xl font-bold text-white text-center">Leaderboard</h2>
+        <ul className="list-decimal mx-auto max-w-md">
+          {game.players
+            .sort((a, b) => b.points - a.points)
+            .map((item) => (
+              <li key={item.id} className="text-gray-400 text-lg flex justify-between border-b border-gray-600 py-2">
+                <div>{item.name}</div>
+                <div>{item.points}</div>
+              </li>
+            ))}
+        </ul>
+      </section>
     </div>
   );
 };


### PR DESCRIPTION
Reduce size of voting results diagram.

<img width="612" alt="Screenshot 2021-03-15 at 23 02 16" src="https://user-images.githubusercontent.com/1220232/111227369-bf172400-85e2-11eb-9af6-1a4f2c92de68.png">
