### PR TITLE
show game code in lobby

### DIFF
--- a/src/screens/lobby.tsx
+++ b/src/screens/lobby.tsx
@@ -9,6 +9,7 @@ const LobbyScreen: React.FC<{ game: Game }> = ({ game }) => {
         <p className="text-lg font-bold text-white text-center md:text-2xl">
           {game.players.length} <small>/ {game.totalPlayers}</small> people have joined
         </p>
+        <p className="text-lg font-bold text-gray-400 text-center md:text-2xl">{`Game code: ${game.code}`}</p>
         <ul>
           {game.players.map((item) => (
             <li key={item.id} className="text-gray-400 md:text-lg text-center">


### PR DESCRIPTION
[Addressing this issue](https://github.com/futu-sto-tech/gif-me-an-answer-client/issues/41)

Before 
<img width="372" alt="Screenshot 2021-04-15 at 15 53 41" src="https://user-images.githubusercontent.com/19215111/114881017-e855ea80-9e02-11eb-96ce-00a1f4b308fb.png">

After:
<img width="376" alt="Screenshot 2021-04-15 at 15 54 22" src="https://user-images.githubusercontent.com/19215111/114881035-ec820800-9e02-11eb-9721-8e52763d2bfd.png">

Open for ideas for better placement of the game code if you have any suggestion.
Also a though: do we need to worry about `game.code` being undefined? TypeScript should panic accordingly then, right?
